### PR TITLE
Remove Locally Optimistic vendor

### DIFF
--- a/blog/contract-powered-platform/index.md
+++ b/blog/contract-powered-platform/index.md
@@ -290,7 +290,7 @@ The fun part is it feels like this ecosystem is just getting started, and there 
 
 **You could also:**
 - Tune in for [Getting jiggy with JSON Schema at dbt Coalesce](https://coalesce.getdbt.com/agenda/getting-jiggy-with-jsonschema-the-power-of-contracts-for-building-data-systems) or [join the conversation](https://twitter.com/emilyhawkins__) on [Twitter](https://twitter.com/aerialfly).
-- Say hi in [Locally Optimistic Slack](https://locallyoptimistic.slack.com/archives/C043RDEFMBL).
+
 
 As closing context from a Shopify perspective, 9800+ schemas and 1800+ contributors (many of whom are not engineers) is a huge feat. As is deploying hundreds of schema-generated instrumentation blocks to thousands of robots around the world. The model works.
 


### PR DESCRIPTION
If Buz (a free, fully OSS thing that doesn't need or want your company's $) is classified as a `vendor`, Locally Optimistic is a vendor too. We only work with vendors who are onboard to collaborate.

<img width="531" alt="Screen Shot 2022-10-07 at 10 40 58 AM" src="https://user-images.githubusercontent.com/2599880/194580615-b01947ae-9366-4add-88e3-de775cca9634.png">
